### PR TITLE
0.3.0

### DIFF
--- a/src/class-wp-options-page.php
+++ b/src/class-wp-options-page.php
@@ -247,11 +247,11 @@ class WP_Options_Page {
 			],
 			$this->strings
 		);
-		$this->form_attributes = \wp_parse_args(
-			$this->form_attributes,
+		$this->form_attributes = \array_merge(
 			[
 				'novalidate' => 'novalidate'
-			]
+			],
+			$this->form_attributes
 		);
 
 		// force some <form> attributes

--- a/src/class-wp-options-page.php
+++ b/src/class-wp-options-page.php
@@ -798,8 +798,8 @@ class WP_Options_Page {
 		$atts['type'] = $field['input_type'] ?? 'text';
 		$atts['id'] = $name;
 		$atts['name'] = $atts['id'];
-		$atts['class'] = $field['class'] ?? 'regular-text';
 		$atts['value'] = $this->get_field_value( $field );
+		$atts['class'] = $field['class'] ?? 'regular-text';
 		$atts['placeholder'] = $field['placeholder'] ?? false;
 		$atts['aria-describedby'] = $desc ? \esc_attr( $id ) . '-description' : false;
 

--- a/src/class-wp-options-page.php
+++ b/src/class-wp-options-page.php
@@ -242,7 +242,8 @@ class WP_Options_Page {
 			[
 				'notice_error' => '<strong>Error</strong>: %s',
 				'checkbox_enable' => 'Enable',
-				'options_updated' => '<strong>' . \__( 'Settings saved.' ) . '</strong>',
+				'options_updated' => '<strong>' . \esc_html__( 'Settings saved.' ) . '</strong>',
+				'submit_button_label' => \esc_html__( 'Save Changes' ),
 			],
 			$this->strings
 		);
@@ -510,7 +511,7 @@ class WP_Options_Page {
 		$invalid_nonce = ! \wp_verify_nonce( $nonce, $action );
 		$invalid_user = ! \current_user_can( $this->capability );
 		if ( $invalid_nonce || $invalid_user ) {
-			\wp_die( \__( 'Sorry, you are not allowed to access this page.' ), 403 );
+			\wp_die( \esc_html__( 'Sorry, you are not allowed to access this page.' ), 403 );
 		}
 
 		$options = [];
@@ -1068,11 +1069,24 @@ class WP_Options_Page {
 	 * @return void
 	 */
 	protected function render_field_submit ( $field ) {
-		$title = $field['title'] ?? \__( 'Save Changes' );
-		$class = $field['class'] ?? 'button button-primary';
+		$title = $field['title'] ?? $this->strings['submit_button_label'];
+		$atts = $field['attributes'] ?? [];
+
+		$atts['type'] = 'submit';
+		$atts['name'] = $atts['name'] ?? 'submit';
+		$atts['id'] = $atts['id'] ?? $atts['name'];
+		$atts['class'] = $atts['class'] ?? 'button button-primary';
+		$atts['value'] = $atts['value'] ?? $title;
+
 		?>
 		<p class="submit">
-			<input type="submit" name="submit" id="submit" class="<?php echo \esc_attr( $class ) ?>" value="<?php echo \esc_attr( $title ) ?>">
+			<?php $this->do_action( 'before_submit_button' ) ?>
+
+			<button <?php echo self::parse_tag_atts( $atts );  ?>>
+				<?php echo \esc_html( $title ); ?>
+			</button>
+
+			<?php $this->do_action( 'after_submit_button' ) ?>
 		</p>
 		<?php
 	}

--- a/src/class-wp-options-page.php
+++ b/src/class-wp-options-page.php
@@ -797,7 +797,7 @@ class WP_Options_Page {
 		$atts = $field['attributes'] ?? [];
 		$atts['type'] = $field['input_type'] ?? 'text';
 		$atts['id'] = $name;
-		$atts['name'] = $atts['id'];
+		$atts['name'] = $name;
 		$atts['value'] = $this->get_field_value( $field );
 		$atts['class'] = $field['class'] ?? 'regular-text';
 		$atts['placeholder'] = $field['placeholder'] ?? false;

--- a/src/class-wp-options-page.php
+++ b/src/class-wp-options-page.php
@@ -806,7 +806,7 @@ class WP_Options_Page {
 		$this->open_wrapper( $field );
 		?>
 
-		<input <?php echo $atts; ?>>
+		<input <?php echo self::parse_tag_atts( $atts ); ?>>
 
 		<?php $this->do_action( 'after_field_input', $field ); ?>
 

--- a/src/class-wp-options-page.php
+++ b/src/class-wp-options-page.php
@@ -1102,7 +1102,7 @@ class WP_Options_Page {
 
 			$result .= ' ' . \esc_html( $name );
 			if ( $value ) {
-				$result .= '="' . \esc_attr( $value ) . '"'
+				$result .= '="' . \esc_attr( $value ) . '"';
 			}
 		}
 		return trim( $result );

--- a/src/class-wp-options-page.php
+++ b/src/class-wp-options-page.php
@@ -1097,7 +1097,7 @@ class WP_Options_Page {
 		foreach ( $atts as $name => $value ) {
 			if ( ! \is_scalar( $value ) ) throw new \Exception( "Invalid non-scalar value at key \"$name\" in " . __METHOD__ );
 
-			if ( null === $value || false === $value ) continue;
+			if ( in_array( $value, [ false, null ], true ) ) continue;
 			if ( true === $value ) $value = '';
 
 			$result .= ' ' . \esc_html( $name );

--- a/src/class-wp-options-page.php
+++ b/src/class-wp-options-page.php
@@ -521,10 +521,11 @@ class WP_Options_Page {
 			$value = $_POST[ $name ] ?? '';
 
 			// maybe validate
-			if ( $field['__validate'] ) {
+			$validate = $field['@validate'] ?? '';
+			if ( $validate ) {
 				$error = false;
 				try {
-					$field['__validate']( $value, $field );
+					$validate( $value, $field );
 					$this->do_action( 'validate_field_' . $field['type'], $field, $this );
 				} catch ( \Throwable $e ) {
 					$error = $e->getMessage();
@@ -540,7 +541,7 @@ class WP_Options_Page {
 			}
 
 			// maybe sanitize
-			$sanitize = $field['__sanitize'] ?? '';
+			$sanitize = $field['@sanitize'] ?? '';
 			if ( $sanitize ) {
 				if ( \is_scalar( $value ) ) {
 					$value = $sanitize( $value );
@@ -716,8 +717,8 @@ class WP_Options_Page {
 			'description' => '',
 			'default' => '',
 			'attributes' => [],
-			'__sanitize' => null,
-			'__validate' => null,
+			'@sanitize' => null,
+			'@validate' => null,
 			'__is_input' => true,
 		];
 		$field = \array_merge( $defaults, $field );
@@ -730,10 +731,10 @@ class WP_Options_Page {
 				$field['__is_input'] = false;
 				break;
 			case 'textarea':
-				$field['__sanitize'] = 'sanitize_textarea_field';
+				$field['@sanitize'] = 'sanitize_textarea_field';
 				break;
 			default:
-				$field['__sanitize'] = 'sanitize_text_field';
+				$field['@sanitize'] = 'sanitize_text_field';
 				break;
 		}
 

--- a/src/class-wp-options-page.php
+++ b/src/class-wp-options-page.php
@@ -687,25 +687,6 @@ class WP_Options_Page {
 
 	/**
 	 * @since 0.1.0
-	 * @param string $icon
-	 * @return string
-	 */
-	protected function get_icon ( $icon ) {
-		$icon = \esc_attr( trim( $icon ) );
-		if ( 0 === \strpos( $icon, 'dashicons-' ) ) {
-			return " <span class=\"dashicons $icon\" aria-hidden=\"true\"></span>";
-		}
-		if ( 0 === \strpos( $icon, 'data:image/' ) || 0 === \strpos( $icon, 'https://' ) ) {
-			return " <img src=\"$icon\" aria-hidden=\"true\">";
-		}
-		if ( $icon ) {
-			return " <span class=\"$icon\" aria-hidden=\"true\"></span>";
-		}
-		return '';
-	}
-
-	/**
-	 * @since 0.1.0
 	 * @param array $field
 	 * @return array
 	 */
@@ -714,7 +695,6 @@ class WP_Options_Page {
 			'id' => null,
 			'type' => 'text',
 			'title' => null,
-			'title_icon' => null,
 			'description' => '',
 			'default' => '',
 			'attributes' => [],
@@ -778,11 +758,10 @@ class WP_Options_Page {
 		$id = $field['id'];
 		$name = $field['name'];
 		$title = $field['title'] ?? $id;
-		$icon = $this->get_icon( $field['title_icon'] );
 		?>
 		<tr>
 			<th scope="row">
-				<label for="<?php echo \esc_attr( $name ); ?>"><?php echo \esc_html( $title ) . $icon ?></label>
+				<label for="<?php echo \esc_attr( $name ); ?>"><?php echo \esc_html( $title ) ?></label>
 			</th>
 			<td>
 		<?php
@@ -1021,11 +1000,10 @@ class WP_Options_Page {
 	 */
 	protected function render_field_title ( $field ) {
 		$id = $field['id'] ? $this->field_prefix . $field['id'] : '';
-		$icon = $this->get_icon( $field['title_icon'] );
 		$desc = $field['description'];
 		$class = $field['class'] ?? '';
 		?>
-		<h1 id="<?php echo \esc_attr( $id ) ?>" class="<?php echo \esc_attr( $class ) ?>"><?php echo \esc_html( $field['title'] ) . $icon ?></h1>
+		<h1 id="<?php echo \esc_attr( $id ) ?>" class="<?php echo \esc_attr( $class ) ?>"><?php echo \esc_html( $field['title'] ) ?></h1>
 		<?php if ( $desc ) : ?>
 		<p><?php echo $desc ?></p>
 		<?php endif ?>
@@ -1039,11 +1017,10 @@ class WP_Options_Page {
 	 */
 	protected function render_field_subtitle ( $field ) {
 		$id = $field['id'] ? $this->field_prefix . $field['id'] : '';
-		$icon = $this->get_icon( $field['title_icon'] );
 		$desc = $field['description'];
 		$class = $field['class'] ?? '';
 		?>
-		<h2 id="<?php echo esc_attr( $id ) ?>" class="<?php echo \esc_attr( $class ) ?>"><?php echo \esc_html( $field['title'] ) . $icon ?></h2>
+		<h2 id="<?php echo esc_attr( $id ) ?>" class="<?php echo \esc_attr( $class ) ?>"><?php echo \esc_html( $field['title'] ) ?></h2>
 
 		<?php if ( $desc ) : ?>
 		<p><?php echo $desc ?></p>

--- a/src/class-wp-options-page.php
+++ b/src/class-wp-options-page.php
@@ -254,9 +254,6 @@ class WP_Options_Page {
 			$this->form_attributes
 		);
 
-		// force some <form> attributes
-		$this->form_attributes['method'] = 'POST';
-
 		$this->init_hooks();
 		$this->init_fields();
 		$this->handle_options();
@@ -618,6 +615,8 @@ class WP_Options_Page {
 	 * @return void
 	 */
 	public function render_page () {
+		// force some <form> attributes
+		$this->form_attributes['method'] = 'POST';
 		$this->form_attributes['action'] = \remove_query_arg( '_wp_http_referer' );
 		?>
 		<div class="wrap">
@@ -634,10 +633,6 @@ class WP_Options_Page {
 			<?php $this->render_credits() ?>
 		</div>
 		<?php
-
-		if ( $this->credits ) {
-
-		}
 	}
 
 	/**

--- a/src/class-wp-options-page.php
+++ b/src/class-wp-options-page.php
@@ -1133,6 +1133,17 @@ class WP_Options_Page {
 	}
 
 	/**
+	 * Check if this instance page supports a given feature.
+	 *
+	 * @since 0.3.0
+	 * @param string $feature string The name of a feature to test support for.
+	 * @return bool True if the gateway supports the feature, false otherwise.
+	 */
+	public function supports ( $feature ) {
+		return \in_array( $feature, $this->supports );
+	}
+
+	/**
 	 * @since 0.3.0
 	 * @param array $atts
 	 * @return string


### PR DESCRIPTION
Changes:

- Added `attributes` property to all fields.
- Removed `subtitle` title. The `title` field now has `tag` property (default is `h2`).
- Added optional credits on admin footer (only in the page). To disable, just set the `WP_Options_Page::$credits` to `false`.
- new hooks.
- new methods.
- rename `__sanitize` prop to `@sanitize`.
- rename `__validate` prop to `@validate`.